### PR TITLE
Experiment on Putting Driver Worker on Process

### DIFF
--- a/vllm/executor/mp_distributed_executor.py
+++ b/vllm/executor/mp_distributed_executor.py
@@ -137,11 +137,11 @@ class MultiprocessingDistributedExecutor(DistributedExecutorBase):
                           max_parallel_loading_workers)
         # self.driver_exec_model = make_async(self.driver_worker.execute_model)
 
-        def exec_model(*args, **kwargs):
-            output = self.driver_worker.execute_method("execute_model", *args, **kwargs)
-            return output.get()
+        # def exec_model(*args, **kwargs):
+        #     output = self.driver_worker.execute_method("execute_model", *args, **kwargs)
+        #     return output.get()
 
-        self.driver_exec_model = exec_model
+        # self.driver_exec_model = exec_model
 
         self.pp_locks: Optional[List[asyncio.Lock]] = None
 
@@ -158,7 +158,11 @@ class MultiprocessingDistributedExecutor(DistributedExecutorBase):
         Passing None will cause the driver to stop the model execution
         loop running in each of the remote workers.
         """
-        return self.driver_worker.execute_model(execute_model_req)
+        # return self.driver_worker.execute_model(execute_model_req)
+        output = self.driver_worker.execute_method(
+            "execute_model", execute_model_req)
+        return output.get()
+
 
     def _run_workers(
         self,

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -162,12 +162,6 @@ class Worker(LocalOrDistributedWorkerBase):
         else:
             raise RuntimeError(
                 f"Not support device type: {self.device_config.device}")
-
-        print (
-            'world_size', os.environ['WORLD_SIZE'],
-            'rank', os.environ['RANK'],
-            'init', torch.distributed.is_initialized()
-        )
         # Initialize the distributed environment.
         init_worker_distributed_environment(self.vllm_config, self.rank,
                                             self.distributed_init_method,

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -162,6 +162,12 @@ class Worker(LocalOrDistributedWorkerBase):
         else:
             raise RuntimeError(
                 f"Not support device type: {self.device_config.device}")
+
+        print (
+            'world_size', os.environ['WORLD_SIZE'],
+            'rank', os.environ['RANK'],
+            'init', torch.distributed.is_initialized()
+        )
         # Initialize the distributed environment.
         init_worker_distributed_environment(self.vllm_config, self.rank,
                                             self.distributed_init_method,


### PR DESCRIPTION
The TRL strategy is to  create a `vllm.LLM` process on the training node, the reason for this now is
- make it efficient to update weights at every step

In the single GPU mode, this is straightforward. However, this causes problems for `MultiprocessingDistributedExecutor` required for TP
- for TP `torch.distributed` needs to be initialized, and thus the training process needs to spawn the VLLM worker, because `torch.cuda` can only be initialized once in a process
- thus the `driver_worker` cannot be together with the `vllm.LLM` process, and this incurs overhead during the decode.

To use
- set `VLLM_WORKER_MULTIPROC_DEVICE_OFFSET` to greater than 1, and this acts as an local_rank offset to deploy vllm workers away from `local_rank=0`
- must set `enforce_eager` as we are having problems with `async_callback`