### PR TITLE
Allow VLLM Parallel to Handle Larger Actual World Size (External Launcher)

### DIFF
--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -858,7 +858,9 @@ def init_distributed_environment(
         world_size = torch.distributed.get_world_size()
         world_size_actual = config.parallel_config.world_size_across_dp
 
-        assert world_size_actual < world_size, "Need to increase world_size"
+        assert world_size % world_size_actual == 0, (
+            f"DP*PP*TP={world_size_actual} needs to divide world size={world_size}"
+        )
         ranks = [
             list(range(i*world_size_actual, (i+1)*world_size_actual)) 
             for i in range(world_size // world_size_actual )


### PR DESCRIPTION
For External Launcher TorchRUN usecase, we need to co-llocate the VLLM with the trainer, which could be running at a different world size. 
- in this scenario, we cannot set `CUDA_VISIBLE_DEVICES` because the vllm process is the same process and not a spawned process.

IOW
- `torch.distributed.get_world_size()`: actual world size
- `config.parallel_config.world_size_across_dp`: world size required by VLLM, and assume this divides the above world size

So then we assume the actual world isze is sharded up into parallel VLLM deployments